### PR TITLE
fix: Update cognito.ts file with Node js 16x

### DIFF
--- a/src/cognito.ts
+++ b/src/cognito.ts
@@ -40,7 +40,7 @@ export class Cognito extends Construct {
 
     const domainValidator = new NodejsFunction(this, 'domainValidator', {
       entry: 'src/resources/cognitoDomain/domainValidator.js',
-      runtime: Runtime.NODEJS_14_X,
+      runtime: Runtime.NODEJS_16_X,
       architecture: Architecture.ARM_64,
       timeout: Duration.seconds(60),
       environment: {


### PR DESCRIPTION
Fixes #

Updating the nodeJs runtime as deployment is failing 

 | CREATE_FAILED        | AWS::Lambda::Function                           | CognitodomainValidatorC88C5F
F9
Resource handler returned message: "The runtime parameter of nodejs14.x is no longer supported for creating or upda
ting AWS Lambda functions. We recommend you use the new runtime (nodejs20.x) while creating or updating functions.
(Service: Lambda, Status Code: 400, Request ID: xxxx)" (RequestToken: xxxx, HandlerErrorCode: InvalidRequest)